### PR TITLE
Working, basic Rust <--> duktape linkage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/duktape-releases"]
+	path = deps/duktape-releases
+	url = https://github.com/svaarala/duktape-releases.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,23 @@
 name = "rusty-duktape"
 version = "0.1.0"
 dependencies = [
+ "gcc 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "getopts"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,13 @@
 name = "rusty-duktape"
 version = "0.1.0"
 authors = ["Tim Caswell <tim@creationix.com>"]
+build = "build.rs"
 
 [dependencies]
 # duktape = "0.0.2"
 # libuv-sys = "0.1.0"
 getopts = "0.2"
+libc = "0.2"
+
+[build-dependencies]
+gcc = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+// build.rs
+
+// Bring in a dependency on an externally maintained `gcc` package which manages
+// invoking the C compiler.
+extern crate gcc;
+
+fn main() {
+    gcc::compile_library("libduktape.a",
+        &["deps/duktape-releases/src/duktape.c",
+          "src/duk_rust_link.c"]);
+}

--- a/src/duk_rust_link.c
+++ b/src/duk_rust_link.c
@@ -1,0 +1,13 @@
+
+// Silly duktape header linkings because Rust doesn't do it (yet?),
+// and `bindgen` doesn't work good enough yet.
+
+#include "../deps/duktape-releases/src/duktape.h"
+
+duk_context *rust_duk_create_heap_default(void) {
+  return duk_create_heap_default();
+}
+
+duk_int_t rust_duk_peval_file(duk_context *ctx, const char *path) {
+  return duk_peval_file(ctx, path);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,25 @@
+// stdlib imports
+use std::{env, fs};
+use std::ffi::CString;
+
+// module imports
+extern crate libc;
+use libc::{c_char, c_int};
+
 extern crate getopts;
 use getopts::Options;
-use std::env;
+//
+
+// Intentionally has the same name as the C struct
+#[allow(non_camel_case_types)]
+enum duk_context {}
+
+extern {
+    fn rust_duk_create_heap_default() -> *mut duk_context;
+    fn rust_duk_peval_file(ctx: *mut duk_context, path: *const c_char) -> c_int;
+    fn duk_destroy_heap(ctx: *mut duk_context);
+}
+
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} FILE [options]", program);
@@ -8,25 +27,44 @@ fn print_usage(program: &str, opts: Options) {
 }
 
 fn main() {
+    // setup, args gathering
     let args: Vec<String> = env::args().collect();
     let program = args[0].clone();
 
+    // process arguments
     let mut opts = Options::new();
-    opts.optopt("o", "", "set output file name", "NAME");
+    opts.optopt("o", "output", "set output file name", "FILE");
     opts.optflag("h", "help", "print this help menu");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m }
         Err(f) => { panic!(f.to_string()) }
     };
+
+    // --help
     if matches.opt_present("h") {
         print_usage(&program, opts);
         return;
     }
-    let output = matches.opt_str("o");
+
+    // let output = matches.opt_str("o");
     let input = if !matches.free.is_empty() {
         matches.free[0].clone()
     } else {
         print_usage(&program, opts);
         return;
     };
+
+    let js_path = match fs::canonicalize(input) {
+        Ok(m) => { m }
+        Err(f) => { panic!(f.to_string()) }
+    };
+
+    let c_js_path = CString::new(js_path.to_str().unwrap()).unwrap();
+
+    let context: *mut duk_context;
+    unsafe {
+        context = rust_duk_create_heap_default();
+        rust_duk_peval_file(context, c_js_path.as_ptr());
+        duk_destroy_heap(context);
+    }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+print("Hello World!")


### PR DESCRIPTION
Currently runs JS files: `target/debug/rusty-duktape test.js`

Clone with `--depth=1` for submodules

```
Jeremiah@Jeremiahs-MBP ~/D/rustyduk> cargo build

   Compiling rusty-duktape v0.1.0 (file:///Users/Jeremiah/Documents/rustyduk)

Jeremiah@Jeremiahs-MBP ~/D/rustyduk> target/debug/rusty-duktape 

Usage: target/debug/rusty-duktape FILE [options]



Options:

    -o, --output FILE   set output file name

    -h, --help          print this help menu

Jeremiah@Jeremiahs-MBP ~/D/rustyduk> target/debug/rusty-duktape test.js

Hello World!

Jeremiah@Jeremiahs-MBP ~/D/rustyduk> 
```
